### PR TITLE
Añadido el paquete , Yago Otero Martínez

### DIFF
--- a/src/ud4/YagoOteroMartinez/Cliente.java
+++ b/src/ud4/YagoOteroMartinez/Cliente.java
@@ -1,0 +1,14 @@
+package ud4.a11maloscheiros.Yago_Otero_Martinez;
+public class Cliente extends NombreCliente{
+    String nombre;
+    int edad;
+
+    public Cliente(String nombre, int edad) {
+        super(nombre);
+        this.edad = edad;
+    }
+
+    
+
+
+}

--- a/src/ud4/YagoOteroMartinez/NombreCliente.java
+++ b/src/ud4/YagoOteroMartinez/NombreCliente.java
@@ -1,0 +1,13 @@
+package ud4.a11maloscheiros.Yago_Otero_Martinez;
+
+// Ejemplo de clase muy básica
+public class NombreCliente {
+
+    String nombre;
+
+    public NombreCliente(String nombre) {
+        this.nombre = nombre;
+    }
+
+    
+}

--- a/src/ud4/YagoOteroMartinez/Ordenador.java
+++ b/src/ud4/YagoOteroMartinez/Ordenador.java
@@ -1,0 +1,26 @@
+package ud4.a11maloscheiros.Yago_Otero_Martinez;
+
+public class Ordenador extends Servidor{
+    String so;
+
+    Cliente cliente;
+
+
+    public Ordenador(String cpu, String ram, String grafica, String fuente, String disco, String so, Cliente cliente) {
+        super(cpu, ram, grafica, fuente, disco);
+        this.so = so;
+        this.cliente = cliente;
+    }
+
+
+
+
+    @Override
+    void levantarServidorWeb() {
+        throw new ArithmeticException("Un ordenador no puede levantar el servidor....");
+    }
+
+
+    
+    
+}

--- a/src/ud4/YagoOteroMartinez/README.md
+++ b/src/ud4/YagoOteroMartinez/README.md
@@ -1,0 +1,7 @@
+Hice dos ejemplos:
+
+1.Clase demasiado simple donde invoco a NombreCliente.java con solo ese String en Cliente.java 
+
+2.Legado rexeitado (refused bequest): (Heréncia erronea)
+    Donde existe servidor que tiene unos métodos con unos atributos que a su vez no se utilizan en Ordenador (es su subclase)
+    entonces hereda de un padre del que no coge nada e incluso el método hice que soltara una excepción 

--- a/src/ud4/YagoOteroMartinez/Servidor.java
+++ b/src/ud4/YagoOteroMartinez/Servidor.java
@@ -1,0 +1,26 @@
+package ud4.a11maloscheiros.Yago_Otero_Martinez;
+
+// Ejemplo de mala herencia , refused bequest
+public class Servidor {
+    String cpu, ram, grafica, fuente, disco;
+
+    
+
+
+    public Servidor(String cpu, String ram, String grafica, String fuente, String disco) {
+        this.cpu = cpu;
+        this.ram = ram;
+        this.grafica = grafica;
+        this.fuente = fuente;
+        this.disco = disco;
+    }
+
+
+
+
+    void levantarServidorWeb() {
+
+        System.out.println("Levantando servidor");
+    }
+
+}


### PR DESCRIPTION
Añadido el paquete , Yago Otero Martínez

Hice dos ejemplos:

1.Clase demasiado simple donde invoco a NombreCliente.java con solo ese String en Cliente.java 

2.Legado rexeitado (refused bequest): (Heréncia erronea)
    Donde existe servidor que tiene unos métodos con unos atributos que a su vez no se utilizan en Ordenador (es su subclase)
    entonces hereda de un padre del que no coge nada e incluso el método hice que soltara una excepción 